### PR TITLE
Allow Decorators to have parents

### DIFF
--- a/src/Decorators/Abstracts/Decorator.php
+++ b/src/Decorators/Abstracts/Decorator.php
@@ -13,6 +13,18 @@ abstract class Decorator
      * @var Element
      */
     protected $element;
+    
+    /**
+     * Applies this decorator immediately
+     * before it's parent (instead of after).
+     * Only relevant, if $this->getParentDecorator()
+     * actually returns a parent.
+     * 
+     * TODO: Make this work.
+     *
+     * @var bool
+     */
+    protected $applyBeforeParent = false;    
 
     /**
      * Decorator constructor.
@@ -44,5 +56,19 @@ abstract class Decorator
      * Perform decorations on $this->element.
      */
     public abstract function decorate();
+    
+    /**
+     * Overwrite to return Full Qualified Class Name
+     * of Parent Decorator (must extend Decorator class).
+     * $this decorator is applied immediately after it's parent,
+     * (or before, if $applyBeforeParent is set to true).
+     *
+     * TODO: Make this work.
+     *
+     */
+    public function getParentDecorator()
+    {
+        return null;
+    }
 
 }


### PR DESCRIPTION
A parent decorator is applied immediately after (and only if) it's parent decorator is applied. The child can also choose to be applied befor it's parent.